### PR TITLE
Reduce allocations in main loop of HIDS queries

### DIFF
--- a/src/PQDashboard/XDAClient.cs
+++ b/src/PQDashboard/XDAClient.cs
@@ -115,13 +115,13 @@ namespace PQDashboard
             string requestVerificationHeaderToken = await GenerateRequestVerificationHeaderTokenAsync(cancellationToken);
 
             using (HttpRequestMessage request = ConfigureRequest(HttpMethod.Post, url, requestVerificationHeaderToken, query))
-            using (HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken))
+            using (HttpResponseMessage response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken))
             using (Stream stream = await response.Content.ReadAsStreamAsync())
             using (TextReader reader = new StreamReader(stream))
             {
                 while (true)
                 {
-                    string line = await reader.ReadLineAsync();
+                    string line = reader.ReadLine();
 
                     if (line == null)
                         break;


### PR DESCRIPTION
`HttpCompletionOption` specifies whether the call to `HttpClient.SendAsync()` should return after reading just the headers, or also the entirety of the content of the response. In this case, we want to stream the response and process data on the way by to reduce overall memory usage.

It seems also that `StreamReader.ReadLineAsync()` was causing performance issues, likely because of the need to allocate lots of small tasks. The synchronous version seems to perform significantly better.

It's hard to say which of these was the primary cause for performance issues since the performance didn't improve at all unless I applied both of these changes. I think this is because the `HttpCompletionOption.ResponseContentRead` option was masking the performance issues with `StreamReader.ReadLineAsync()` by enabling it to complete synchronously.

Ticket 1324