### PR TITLE
Added max zoom back into leaflet. Not having it causes leaflet to use…

### DIFF
--- a/src/PQDashboard/Scripts/Default.js
+++ b/src/PQDashboard/Scripts/Default.js
@@ -3865,6 +3865,7 @@ function loadLeafletMap(theDiv) {
         leafletMap[currentTab] = L.map(theDiv, {
             center: [35.0456, -85.3097],
             zoom: 6,
+            maxZoom: arcGis.BaseLayer.length == 0 ? 15 : 20,
             zoomControl: false,
             attributionControl: false
         });


### PR DESCRIPTION
… the base-layer's max zoom, but it is seen as beneficial to be able to zoom in more than that for arcGIS