### PR TITLE
Map metric animation fixes Ticket_1324

### DIFF
--- a/src/PQDashboard/MapMetrics/MapMetricQuery.cs
+++ b/src/PQDashboard/MapMetrics/MapMetricQuery.cs
@@ -531,7 +531,7 @@ namespace PQDashboard.MapMetrics
             var hidsQuery = new
             {
                 StartTime = StartTime,
-                EndTime = EndTime,
+                StopTime = EndTime,
                 Channels = channels,
                 AggregateDuration = $"{AnimationInterval}m"
             };

--- a/src/PQDashboard/MapMetrics/MapMetricQuery.cs
+++ b/src/PQDashboard/MapMetrics/MapMetricQuery.cs
@@ -488,7 +488,6 @@ namespace PQDashboard.MapMetrics
                 $"    Phase.Name IN ({phaseList})";
 
             List<int> channels;
-            Func<int, double> getNominalValue;
             Action<int, int, double> populateAction;
 
             using (AdoDataConnection connection = new AdoDataConnection("dbOpenXDA"))
@@ -510,21 +509,15 @@ namespace PQDashboard.MapMetrics
                     })
                     .ToDictionary(mapping => mapping.ChannelID);
 
-                getNominalValue = channelID =>
-                {
-                    var mapping = lookup.Values.Take(0).SingleOrDefault();
-                    return lookup.TryGetValue(channelID, out mapping)
-                        ? mapping.PerUnitValue ?? 1.0D
-                        : 1.0D;
-                };
-
                 populateAction = (frameIndex, channelID, value) =>
                 {
                     var mapping = lookup.Values.Take(0).SingleOrDefault();
                     if (!lookup.TryGetValue(channelID, out mapping))
                         return;
 
-                    parentAction(frameIndex, mapping.MeterID, value);
+                    double nominalValue = mapping.PerUnitValue ?? 1.0D;
+                    double perUnitValue = value / nominalValue;
+                    parentAction(frameIndex, mapping.MeterID, perUnitValue);
                 };
             }
 


### PR DESCRIPTION
Specifying `EndTime` instead of `StopTime` made the HIDS API assume there was no end to the query. This was causing massive performance issues. I may have wasted a lot of effort optimizing things. 🤦 

Through this latest round of testing, I noticed the `getNominalValue()` function wasn't being used. I also noticed that `populateAction()` was already looking up the mapping to get the `MeterID` so I simply applied the nominal value there to convert to per-unit.