### PR TITLE
DASH-17 Filter Completeness/Correctness Detail pane by meter selection

### DIFF
--- a/src/PQDashboard/Controllers/Completeness/TableDataController.cs
+++ b/src/PQDashboard/Controllers/Completeness/TableDataController.cs
@@ -35,6 +35,8 @@ namespace PQDashboard.Controllers
                 "DECLARE @meterList AS varchar(max) = {1} " +
                 "DECLARE @context as nvarchar(20) = {2} " +
                 "" +
+                "SELECT * INTO #MeterSelection FROM dbo.String_to_int_table(@meterList, ',') " +
+                "" +
                 "SELECT " +
                 "	FirstSummary.ID theeventid, " +
                 "	Meter.ID themeterid, " +
@@ -68,7 +70,8 @@ namespace PQDashboard.Controllers
                 "		WHERE " +
                 "			FirstSummary.MeterID = Meter.ID AND " +
                 "			FirstSummary.Date = MeterDataQualitySummary.Date " +
-                "	) FirstSummary";
+                "	) FirstSummary " +
+                "WHERE Meter.ID IN (SELECT * FROM  #MeterSelection)";
 
             Tab = "Completeness";
         }

--- a/src/PQDashboard/Controllers/Correctness/TableDataController.cs
+++ b/src/PQDashboard/Controllers/Correctness/TableDataController.cs
@@ -35,6 +35,8 @@ namespace PQDashboard.Controllers
                 "DECLARE @meterList AS varchar(max) = {1} " +
                 "DECLARE @context as nvarchar(20) = {2} " +
                 "" +
+                "SELECT * INTO #MeterSelection FROM dbo.String_to_int_table(@meterList, ',') " +
+                "" +
                 "SELECT " +
                 "	FirstSummary.ID theeventid, " +
                 "	Meter.ID themeterid, " +
@@ -69,7 +71,8 @@ namespace PQDashboard.Controllers
                 "		WHERE " +
                 "			FirstSummary.MeterID = Meter.ID AND " +
                 "			FirstSummary.Date = MeterDataQualitySummary.Date " +
-                "	) FirstSummary";
+                "	) FirstSummary " +
+                "WHERE Meter.ID IN (SELECT * FROM  #MeterSelection)";
 
             Tab = "Correctness";
         }

--- a/src/PQDashboard/Scripts/Default.js
+++ b/src/PQDashboard/Scripts/Default.js
@@ -3189,7 +3189,7 @@ function manageTabsByDate(theNewTab, thedatefrom, thedateto) {
     resizeMapAndMatrix(theNewTab);
 
     if (globalContext != "custom")
-        getTableDivData('getDetailsForSites' + currentTab, 'Detail' + currentTab, meterList.selectedIdsString(), tableDate);
+        getTableDivData(meterList.selectedIdsString(), tableDate);
     else {
         if ($('#Detail' + currentTab + 'Table').children().length > 0) {
             var parent = $('#Detail' + currentTab + 'Table').parent();


### PR DESCRIPTION
Both of these controllers were assigning the meter selections to a local variable in the query and then doing nothing with it.

Also in `Default.js`, the signature for `getTableDivData()` must have changed at some point. One of the three callsites was passing four parameters, but the function only accepts two parameters. JavaScript silently throws out any extra parameters which, incidentally, were the two parameters the function actually needed. This was causing the `TableDivData` request to fail specifically when changing between asset groups, so the Detail pane wasn't updating.