### PR TITLE
DASH-21 In Home.cshtml, populate defaultAssetGroupID with the value of ViewBag.AssetGroup

### DIFF
--- a/src/PQDashboard/Views/Main/Home.cshtml
+++ b/src/PQDashboard/Views/Main/Home.cshtml
@@ -57,7 +57,6 @@
         ViewBag.scInstance = connection.ExecuteScalar<string>("SELECT Value FROM Settings WHERE Name = 'SCInstance'");
         ViewBag.openSEEInstance = connection.ExecuteScalar<string>("SELECT Value FROM Settings WHERE Name = 'OpenSEEInstance'");
         ViewBag.seBrowserInstance = connection.ExecuteScalar<string>("SELECT Value FROM Settings WHERE Name = 'SEBrowserInstance'");
-
     }
 
     using (DataContext dataContext = new DataContext("dbOpenXDA"))
@@ -86,11 +85,14 @@
         ViewBag.arcGisBase = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
     }
 
-    int defaulAssetGroupID = -1;
+    int defaultAssetGroupID;
 
-    if (assetGroups.Any())
+    if (!int.TryParse(ViewBag.AssetGroup, out defaultAssetGroupID) || !assetGroups.Any(g => g.ID == defaultAssetGroupID))
     {
-        defaulAssetGroupID = assetGroups.First().ID;
+        defaultAssetGroupID = assetGroups
+            .Select(assetGroup => assetGroup.ID)
+            .DefaultIfEmpty(-1)
+            .First();
     }
 
     string[] tabs = new[] { "Events", "Disturbances", "Faults", "Breakers", "Extensions", "Trending", "Completeness", "Correctness" };
@@ -122,7 +124,7 @@
         }
     </style>
     <script>
-        var mg = @defaulAssetGroupID;
+        var mg = @defaultAssetGroupID;
         var homePath = '@Html.Raw(Url.Content("~/"))';
         var historianConnection = '@historianConnection';
         var xdaInstance = '@Html.Raw(ViewBag.xdaInstance)';


### PR DESCRIPTION
`ViewBag.AssetGroup` was already being populated with the query:
`SELECT AltText1 FROM ValueList WHERE Text = 'DefaultView.AssetGroup' AND GroupID = (SELECT ID FROM ValueListGroup WHERE Name = 'System')`

The result of that query is a string so this PR parses that string as an integer and checks to see if it's in `assetGroups`. If it's not, we fall back on the default of using the first ID in `assetGroups` or `-1` if there are no asset groups.

Also fixes the typo in `defaulAssetGroupID`.